### PR TITLE
chore: allow write for commit job

### DIFF
--- a/.github/workflows/readme-scribe.yml
+++ b/.github/workflows/readme-scribe.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   readme-scribe:


### PR DESCRIPTION
This job uses ephemeral github credentials to update .github/README.md (which is what folks see when they go to https://github.com/anchore ). Since it uses an ephemeral write token, it seems safe. I previously accidentally changed it to use `read` permissions, which won't work.